### PR TITLE
update pwm pins for NX in the test code

### DIFF
--- a/samples/test_all_apis.py
+++ b/samples/test_all_apis.py
@@ -114,7 +114,7 @@ pin_datas = {
         # Other pin modes:
         'cvm_pin': 'GPIO09',
         'tegra_soc_pin': 'AUD_MCLK',
-        'all_pwms': (32, 33),
+        'all_pwms': (15, 32, 33),
     },
     'CLARA_AGX_XAVIER': {
         # Pre-test configuration, if boot-time pinmux doesn't set up PWM pins:


### PR DESCRIPTION
- pin 15 can be configured in the NX as a 3rd PWM output
- related to NVIDIA/jetson-gpio#63