### PR TITLE
Update gpio_pin_data.py for Jetson Orin Nano Super

### DIFF
--- a/lib/python/Jetson/GPIO/gpio_pin_data.py
+++ b/lib/python/Jetson/GPIO/gpio_pin_data.py
@@ -89,6 +89,7 @@ compats_jetson_orins_nano = (
     "nvidia,p3768-0000+p3767-0004",
     "nvidia,p3509-0000+p3767-0005",
     "nvidia,p3768-0000+p3767-0005",
+    "nvidia,p3768-0000+p3767-0005-super",
 )
 
 JETSON_ORIN_PIN_DEFS = [


### PR DESCRIPTION
Jetson Orin Nano Super support. Fixed "('Could not determine Jetson model')". Tested on JetPack 6.2