### PR TITLE
(Orin NX/Nano) Add pinmux configuration warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,11 @@ None.
 It is possible that the GPIO you are trying to use is already being used
 external to the current application. In such a condition, the Jetson GPIO
 library will warn you if the GPIO being used is configured to anything but the
-default direction (input). It will also warn you if you try cleaning up before
-setting up the mode and channels. To disable warnings, call:
+default direction (input). It will also warn you if:
+* You try cleaning up before setting up the mode and channels.
+* (Orin NX/Nano only) The pinmux for a requested pin is not properly confirgured to GPIO and the correct direction.
+
+To disable warnings, call:
 ```python
 GPIO.setwarnings(False)
 ```

--- a/lib/python/Jetson/GPIO/gpio.py
+++ b/lib/python/Jetson/GPIO/gpio.py
@@ -159,6 +159,10 @@ def _do_one_channel(ch_info, direction, initial, consumer):
     request = gpio_cdev.request_handle(ch_info.line_offset, cdev_direction, initial, consumer)
 
     gpio_cdev.open_line(ch_info, request)
+
+    if _gpio_warnings:
+        gpio_cdev.check_pinmux(ch_info, direction == OUT, _gpio_warnings)
+
     _channel_configuration[ch_info.channel] = direction
 
 

--- a/lib/python/Jetson/GPIO/gpio_pin_data.py
+++ b/lib/python/Jetson/GPIO/gpio_pin_data.py
@@ -47,32 +47,55 @@ JETSON_MODELS = [JETSON_TX1, JETSON_TX2, CLARA_AGX_XAVIER, JETSON_TX2_NX, JETSON
 # - Pin name (TEGRA_SOC mode)
 # - PWM chip sysfs directory
 # - PWM ID within PWM chip
+# - PADCTL Register Block Base Address
+# - PADCTL Register Offset (from base address)
 # The values are used to generate dictionaries that map the corresponding pin
 # mode numbers to the Linux GPIO pin number and GPIO chip directory
 
+JETSON_ORIN_PADCTL_A14 = 0x0C302000
+JETSON_ORIN_PADCTL_A15 = 0x0C303000
+JETSON_ORIN_PADCTL_A5 = 0x02435000
+JETSON_ORIN_PADCTL_A16 = 0x02440000
+JETSON_ORIN_PADCTL_A6 = 0x02436000
+JETSON_ORIN_PADCTL_A21 = 0x02445000
+JETSON_ORIN_PADCTL_A7 = 0x02437000
+JETSON_ORIN_PADCTL_A20 = 0x02444000
+JETSON_ORIN_PADCTL_A25 = 0x02449000
+JETSON_ORIN_PADCTL_A11 = 0x0243B000
+JETSON_ORIN_PADCTL_A8 = 0x02438000
+JETSON_ORIN_PADCTL_A12 = 0x0C301000
+JETSON_ORIN_PADCTL_A17 = 0x02441000
+JETSON_ORIN_PADCTL_A13 = 0x0243D000
+JETSON_ORIN_PADCTL_A0 = 0x02430000
+JETSON_ORIN_PADCTL_A4 = 0x02434000
+JETSON_ORIN_PADCTL_A2 = 0x02432000
+JETSON_ORIN_PADCTL_A24 = 0x02448000
+
+JETSON_ORIN_PAD_CONTROL_REGISTERS = {}
+
 JETSON_ORIN_NX_PIN_DEFS = [
-    (144, 'PAC.06', "tegra234-gpio", 7, 4, 'GPIO09', 'GP167', None, None),
-    (112, 'PR.04', "tegra234-gpio", 11, 17, 'UART1_RTS', 'GP72_UART1_RTS_N', None, None),
-    (50, 'PH.07', "tegra234-gpio", 12, 18, 'I2S0_SCLK', 'GP122', None, None),
-    (122, 'PY.00', "tegra234-gpio", 13, 27, 'SPI1_SCK', 'GP36_SPI3_CLK', None, None),
-    (85, 'PN.01', "tegra234-gpio", 15, 22, 'GPIO12', 'GP88_PWM1', '3280000.pwm', 0),
-    (126, 'PY.04', "tegra234-gpio", 16, 23, 'SPI1_CS1', 'GP40_SPI3_CS1_N', None, None),
-    (125, 'PY.03', "tegra234-gpio", 18, 24, 'SPI1_CS0', 'GP39_SPI3_CS0_N', None, None),
-    (135, 'PZ.05', "tegra234-gpio", 19, 10, 'SPI0_MOSI', 'GP49_SPI1_MOSI', None, None),
-    (134, 'PZ.04', "tegra234-gpio", 21, 9, 'SPI0_MISO', 'GP48_SPI1_MISO', None, None),
-    (123, 'PY.01', "tegra234-gpio", 22, 25, 'SPI1_MISO', 'GP37_SPI3_MISO', None, None),
-    (133, 'PZ.03', "tegra234-gpio", 23, 11, 'SPI0_SCK', 'GP47_SPI1_CLK', None, None),
-    (136, 'PZ.06', "tegra234-gpio", 24, 8, 'SPI0_CS0', 'GP50_SPI1_CS0_N', None, None),
-    (137, 'PZ.07', "tegra234-gpio", 26, 7, 'SPI0_CS1', 'GP51_SPI1_CS1_N', None, None),
-    (105, 'PQ.05', "tegra234-gpio", 29, 5, 'GPIO01', 'GP65', None, None),
-    (106, 'PQ.06', "tegra234-gpio", 31, 6, 'GPIO11', 'GP66', None, None),
-    (41, 'PG.06', "tegra234-gpio", 32, 12, 'GPIO07', 'GP113_PWM7', '32e0000.pwm', 0),
-    (43, 'PH.00', "tegra234-gpio", 33, 13, 'GPIO13', 'GP115', '32c0000.pwm', 0),
-    (53, 'PI.02', "tegra234-gpio", 35, 19, 'I2S0_FS', 'GP125', None, None),
-    (113, 'PR.05', "tegra234-gpio", 36, 16, 'UART1_CTS', 'GP73_UART1_CTS_N', None, None),
-    (124, 'PY.02', "tegra234-gpio", 37, 26, 'SPI1_MOSI', 'GP38_SPI3_MOSI', None, None),
-    (52, 'PI.01', "tegra234-gpio", 38, 20, 'I2S0_SDIN', 'GP124', None, None),
-    (51, 'PI.00', "tegra234-gpio", 40, 21, 'I2S0_SDOUT', 'GP123', None, None)
+    (144, 'PAC.06', "tegra234-gpio", 7, 4, 'GPIO09', 'GP167', None, None, JETSON_ORIN_PADCTL_A24, 0x2C),
+    (112, 'PR.04', "tegra234-gpio", 11, 17, 'UART1_RTS', 'GP72_UART1_RTS_N', None, None, JETSON_ORIN_PADCTL_A0, 0x98),
+    (50, 'PH.07', "tegra234-gpio", 12, 18, 'I2S0_SCLK', 'GP122', None, None, JETSON_ORIN_PADCTL_A4, 0x88),
+    (122, 'PY.00', "tegra234-gpio", 13, 27, 'SPI1_SCK', 'GP36_SPI3_CLK', None, None, JETSON_ORIN_PADCTL_A13, 0x30),
+    (85, 'PN.01', "tegra234-gpio", 15, 22, 'GPIO12', 'GP88_PWM1', '3280000.pwm', 0, JETSON_ORIN_PADCTL_A16, 0x20),
+    (126, 'PY.04', "tegra234-gpio", 16, 23, 'SPI1_CS1', 'GP40_SPI3_CS1_N', None, None, JETSON_ORIN_PADCTL_A13, 0x20),
+    (125, 'PY.03', "tegra234-gpio", 18, 24, 'SPI1_CS0', 'GP39_SPI3_CS0_N', None, None, JETSON_ORIN_PADCTL_A13, 0x10),
+    (135, 'PZ.05', "tegra234-gpio", 19, 10, 'SPI0_MOSI', 'GP49_SPI1_MOSI', None, None, JETSON_ORIN_PADCTL_A13, 0x40),
+    (134, 'PZ.04', "tegra234-gpio", 21, 9, 'SPI0_MISO', 'GP48_SPI1_MISO', None, None, JETSON_ORIN_PADCTL_A13, 0x18),
+    (123, 'PY.01', "tegra234-gpio", 22, 25, 'SPI1_MISO', 'GP37_SPI3_MISO', None, None, JETSON_ORIN_PADCTL_A13, 0x0),
+    (133, 'PZ.03', "tegra234-gpio", 23, 11, 'SPI0_SCK', 'GP47_SPI1_CLK', None, None, JETSON_ORIN_PADCTL_A13, 0x28),
+    (136, 'PZ.06', "tegra234-gpio", 24, 8, 'SPI0_CS0', 'GP50_SPI1_CS0_N', None, None, JETSON_ORIN_PADCTL_A13, 0x8),
+    (137, 'PZ.07', "tegra234-gpio", 26, 7, 'SPI0_CS1', 'GP51_SPI1_CS1_N', None, None, JETSON_ORIN_PADCTL_A13, 0x38),
+    (105, 'PQ.05', "tegra234-gpio", 29, 5, 'GPIO01', 'GP65', None, None, JETSON_ORIN_PADCTL_A0, 0x68),
+    (106, 'PQ.06', "tegra234-gpio", 31, 6, 'GPIO11', 'GP66', None, None, JETSON_ORIN_PADCTL_A0, 0x70),
+    (41, 'PG.06', "tegra234-gpio", 32, 12, 'GPIO07', 'GP113_PWM7', '32e0000.pwm', 0, JETSON_ORIN_PADCTL_A4, 0x80),
+    (43, 'PH.00', "tegra234-gpio", 33, 13, 'GPIO13', 'GP115', '32c0000.pwm', 0, JETSON_ORIN_PADCTL_A4, 0x40),
+    (53, 'PI.02', "tegra234-gpio", 35, 19, 'I2S0_FS', 'GP125', None, None, JETSON_ORIN_PADCTL_A4, 0xA0),
+    (113, 'PR.05', "tegra234-gpio", 36, 16, 'UART1_CTS', 'GP73_UART1_CTS_N', None, None, JETSON_ORIN_PADCTL_A0, 0x90),
+    (124, 'PY.02', "tegra234-gpio", 37, 26, 'SPI1_MOSI', 'GP38_SPI3_MOSI', None, None, JETSON_ORIN_PADCTL_A13, 0x48),
+    (52, 'PI.01', "tegra234-gpio", 38, 20, 'I2S0_SDIN', 'GP124', None, None, JETSON_ORIN_PADCTL_A4, 0x98),
+    (51, 'PI.00', "tegra234-gpio", 40, 21, 'I2S0_SDOUT', 'GP123', None, None, JETSON_ORIN_PADCTL_A4, 0x90)
 ]
 
 compats_jetson_orins_nx = (
@@ -482,7 +505,9 @@ class ChannelInfo(object):
     # @consumer consumer label
     # @gpio_name Linux exported GPIO name
     # @gpio_chip GPIO chip name/instance
-    def __init__(self, channel, line_offset, gpio_name, gpio_chip, pwm_chip_dir, pwm_id):
+    # @reg_block_base_addr base address of the PADCTL register block
+    # @reg_offset offset from reg_block_base_addr for this channel's PADCTL register
+    def __init__(self, channel, line_offset, gpio_name, gpio_chip, pwm_chip_dir, pwm_id, reg_block_base_addr = None, reg_offset = None):
         self.channel = channel
         self.chip_fd = None
         self.line_handle = None
@@ -494,7 +519,11 @@ class ChannelInfo(object):
         self.gpio_chip = gpio_chip
         self.pwm_chip_dir = pwm_chip_dir
         self.pwm_id = pwm_id
+        self.reg_block_base_addr = reg_block_base_addr
+        self.reg_offset = reg_offset
 
+def register_addr(base: int, offset: int) -> int:
+    pass
 
 ids_warned = False
 
@@ -645,13 +674,18 @@ def get_data():
             break
 
     def model_data(key_col, pin_defs):
-        return {x[key_col]: ChannelInfo(
-            x[key_col],
-            x[0],
-            x[1],
-            x[2],
-            pwm_chip_dir=pwm_dirs.get(x[7], None),
-            pwm_id=x[8]) for x in pin_defs}
+        return {
+            x[key_col]: ChannelInfo(
+                x[key_col],
+                x[0],
+                x[1],
+                x[2],
+                pwm_chip_dir=pwm_dirs.get(x[7], None),
+                pwm_id=x[8],
+                reg_block_base_addr=x[9] if 9 < len(x) else None,
+                reg_offset=x[10] if 10 < len(x) else None
+            ) for x in pin_defs
+        }
 
     channel_data = {
         'BOARD': model_data(3, pin_defs),


### PR DESCRIPTION
# Overview
This PR adds the ability to warn the user when they setup a pin, but have an incorrect pinmux configuration. Currently this only works for Orin NX/Nano boards, but this lays the groundwork for other boards in the future.

## Fixes
* Fixes #120
* Fixes #114 